### PR TITLE
Update transform to use compileClient as the client opt is now deprecated

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,21 +60,27 @@ function withSourceMap(src, compiled, name) {
   var generator = new SourceMapGenerator({file: name + '.js'});
 
   compiledLines.forEach(function(l, lineno) {
-    var m = l.match(/^jade\.debug\.unshift\(\{ lineno: ([0-9]+)/);
+    var m = l.match(/^jade(_|\.)debug\.unshift\(\{ lineno: ([0-9]+)/);
     if (m) {
-      generator.addMapping({
-        generated: {
-          line: lineno+2,
-          column: 0
-        },
-        source: name,
-        original: {
-          line: Number(m[1]),
-          column: 0
-        }
-      });
+      var originalLine = Number(m[2]);
+      var generatedLine = lineno + 2;
+
+      if (originalLine > 0) {
+        generator.addMapping({
+          generated: {
+            line: generatedLine,
+            column: 0
+          },
+          source: name,
+          original: {
+            line: originalLine,
+            column: 0
+          }
+        });
+      }
     }
-    var debugRe = /jade\.debug\.(shift|unshift)\([^)]*\);?/;
+
+    var debugRe = /jade(_|\.)debug\.(shift|unshift)\([^)]*\);?/;
     var match;
     while(match = l.match(debugRe)) {
       l = replaceMatchWith(match, '');
@@ -91,7 +97,15 @@ function withSourceMap(src, compiled, name) {
 
 function compile(file, template, options) {
     options.filename= file;
-    var fn =  jade.compileClient(template, options);
+    var fn;
+    if(jade.compileClient) {
+      fn = jade.compileClient(template, options);
+    } else {
+      // jade < 1.0
+      options.client = true;
+      fn = jade.compile(template, options);
+    }
+
     var generated = fn.toString();
     return PREFIX + withSourceMap(template, generated, file);
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "source-map": "~0.1.29"
   },
   "peerDependencies": {
-    "jade": ">=1.0.0"
+    "jade": "*"
   },
   "devDependencies": {
     "tap": "~0.4.0",


### PR DESCRIPTION
I began receiving the following when applying the transform with jade 1.0:

```
Error: The `client` option is deprecated, use `jade.compileClient`
    at Function.res.toString (/Users/will/src/ayr-frontend/node_modules/jade/lib/jade.js:164:17)
    at compile (/Users/will/src/ayr-frontend/node_modules/browserify-jade/index.js:96:24)
```

This uses the newer compileClient call but unfortunately isn't compatible with jade pre 1.0.

Also allow for browserify 3.x as a dev dependency.
