### PR TITLE
Update pug dependency to ^3.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "babel-core": "^6.26.0",
     "browserify-transform-tools": "^1.6.0",
     "convert-source-map": "~1.3.0",
-    "pug": "2.0.4",
     "source-map": "^0.5.6",
+    "pug": "^3.0.2",
     "through": "^2.3.8"
   },
   "devDependencies": {


### PR DESCRIPTION
Update pug dependency to 3.0.2 to fix npm audit warnings.

This may be a breaking change for projects affected by the change from pug 2 to 3. See [https://pugjs.org/api/migration-v3.html](url). Pug 3 minimum node version is 10.